### PR TITLE
Add Observer design pattern project

### DIFF
--- a/DesignPatterns.sln
+++ b/DesignPatterns.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Singleton", "Singleton\Sing
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Factory", "Factory\Factory.csproj", "{DB2F2392-F3EC-45FA-8D88-FE613B7B7B34}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Observer", "Observer\Observer.csproj", "{15A4A9B1-8E47-465A-A9B0-2170C9907387}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -97,6 +99,18 @@ Global
 		{DB2F2392-F3EC-45FA-8D88-FE613B7B7B34}.Release|x64.Build.0 = Release|Any CPU
 		{DB2F2392-F3EC-45FA-8D88-FE613B7B7B34}.Release|x86.ActiveCfg = Release|Any CPU
 		{DB2F2392-F3EC-45FA-8D88-FE613B7B7B34}.Release|x86.Build.0 = Release|Any CPU
+		{15A4A9B1-8E47-465A-A9B0-2170C9907387}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{15A4A9B1-8E47-465A-A9B0-2170C9907387}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{15A4A9B1-8E47-465A-A9B0-2170C9907387}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{15A4A9B1-8E47-465A-A9B0-2170C9907387}.Debug|x64.Build.0 = Debug|Any CPU
+		{15A4A9B1-8E47-465A-A9B0-2170C9907387}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{15A4A9B1-8E47-465A-A9B0-2170C9907387}.Debug|x86.Build.0 = Debug|Any CPU
+		{15A4A9B1-8E47-465A-A9B0-2170C9907387}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{15A4A9B1-8E47-465A-A9B0-2170C9907387}.Release|Any CPU.Build.0 = Release|Any CPU
+		{15A4A9B1-8E47-465A-A9B0-2170C9907387}.Release|x64.ActiveCfg = Release|Any CPU
+		{15A4A9B1-8E47-465A-A9B0-2170C9907387}.Release|x64.Build.0 = Release|Any CPU
+		{15A4A9B1-8E47-465A-A9B0-2170C9907387}.Release|x86.ActiveCfg = Release|Any CPU
+		{15A4A9B1-8E47-465A-A9B0-2170C9907387}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Observer/ConcreteObserverA.cs
+++ b/Observer/ConcreteObserverA.cs
@@ -1,0 +1,15 @@
+using System;
+
+namespace ObserverPattern
+{
+    public class ConcreteObserverA : IObserver
+    {
+        public void Update(ISubject subject)
+        {
+            if (subject is Subject s)
+            {
+                Console.WriteLine($"ConcreteObserverA: Reacted to the event. New state is: {s.State}");
+            }
+        }
+    }
+}

--- a/Observer/ConcreteObserverB.cs
+++ b/Observer/ConcreteObserverB.cs
@@ -1,0 +1,23 @@
+using System;
+
+namespace ObserverPattern
+{
+    public class ConcreteObserverB : IObserver
+    {
+        public void Update(ISubject subject)
+        {
+            if (subject is Subject s)
+            {
+                // Example: Observer B might only care about states above a certain threshold
+                if (s.State >= 5)
+                {
+                    Console.WriteLine($"ConcreteObserverB: Reacted to the event. New state ({s.State}) is >= 5.");
+                }
+                else
+                {
+                    Console.WriteLine($"ConcreteObserverB: Reacted to the event. New state ({s.State}) is < 5, taking no specific action.");
+                }
+            }
+        }
+    }
+}

--- a/Observer/IObserver.cs
+++ b/Observer/IObserver.cs
@@ -1,0 +1,7 @@
+namespace ObserverPattern
+{
+    public interface IObserver
+    {
+        void Update(ISubject subject);
+    }
+}

--- a/Observer/ISubject.cs
+++ b/Observer/ISubject.cs
@@ -1,0 +1,9 @@
+namespace ObserverPattern
+{
+    public interface ISubject
+    {
+        void Attach(IObserver observer);
+        void Detach(IObserver observer);
+        void Notify();
+    }
+}

--- a/Observer/Observer.csproj
+++ b/Observer/Observer.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework> <!-- Or a version consistent with other projects -->
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Observer/Program.cs
+++ b/Observer/Program.cs
@@ -1,0 +1,41 @@
+using System;
+
+namespace ObserverPattern
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Observer Pattern Example");
+            Console.WriteLine("------------------------\n");
+
+            // Create subject
+            var subject = new Subject();
+
+            // Create observers
+            var observerA = new ConcreteObserverA();
+            var observerB = new ConcreteObserverB();
+
+            // Attach observers to the subject
+            Console.WriteLine("\n--- Attaching Observers ---");
+            subject.Attach(observerA);
+            subject.Attach(observerB);
+
+            // Simulate business logic that changes subject's state
+            Console.WriteLine("\n--- Simulating State Changes ---");
+            subject.SomeBusinessLogic(); // State changes, observers are notified
+            subject.SomeBusinessLogic(); // State changes again
+
+            // Detach an observer
+            Console.WriteLine("\n--- Detaching Observer A ---");
+            subject.Detach(observerA);
+
+            // Simulate another state change
+            Console.WriteLine("\n--- Simulating State Change After Detach ---");
+            subject.SomeBusinessLogic(); // Only Observer B should be notified
+
+            Console.WriteLine("\n------------------------");
+            Console.WriteLine("Observer Pattern Example Finished.");
+        }
+    }
+}

--- a/Observer/README.md
+++ b/Observer/README.md
@@ -1,0 +1,40 @@
+# Observer Pattern Example (C#)
+
+This project demonstrates the Observer design pattern in C#.
+
+## What is the Observer Pattern?
+
+The Observer pattern is a behavioral design pattern that defines a one-to-many dependency between objects. When one object (the "subject" or "observable") changes its state, all its dependents ("observers") are notified and updated automatically.
+
+Key components:
+*   **Subject (`ISubject`):** An interface defining methods for attaching, detaching, and notifying observers.
+*   **ConcreteSubject (`Subject`):** Implements `ISubject`. It maintains a list of observers and sends notifications when its state changes.
+*   **Observer (`IObserver`):** An interface defining the `Update` method, which is called when the subject's state changes.
+*   **ConcreteObserver (`ConcreteObserverA`, `ConcreteObserverB`):** Implement `IObserver`. Each observer registers with a concrete subject to receive updates.
+
+## Project Structure
+
+*   `Observer.csproj`: The C# project file.
+*   `Program.cs`: Contains the `Main` method that demonstrates the Observer pattern in action. It creates a subject, attaches observers, simulates state changes, and shows observers being notified.
+*   `IObserver.cs`: Defines the `IObserver` interface.
+*   `ISubject.cs`: Defines the `ISubject` interface.
+*   `Subject.cs`: The concrete implementation of `ISubject`.
+*   `ConcreteObserverA.cs`: A concrete observer implementation.
+*   `ConcreteObserverB.cs`: Another concrete observer implementation, demonstrating different reactions to updates.
+
+## How to Run
+
+1.  Ensure you have the .NET SDK installed.
+2.  Navigate to the `Observer` directory in your terminal.
+3.  Run the command: `dotnet run`
+
+This will execute the `Program.cs` file, and you will see console output demonstrating the interactions between the subject and observers.
+
+## Design Principles Applied
+
+*   **SOLID:**
+    *   **Single Responsibility Principle:** `Subject` handles state and notifications. Observers handle their specific reactions.
+    *   **Interface Segregation Principle:** `IObserver` and `ISubject` provide focused interfaces.
+*   **KISS (Keep It Simple, Stupid):** The example is straightforward and focuses on the core pattern.
+*   **DRY (Don't Repeat Yourself):** The notification logic is centralized in the `Subject`.
+```

--- a/Observer/Subject.cs
+++ b/Observer/Subject.cs
@@ -1,0 +1,60 @@
+using System.Collections.Generic;
+
+namespace ObserverPattern
+{
+    public class Subject : ISubject
+    {
+        private List<IObserver> _observers = new List<IObserver>();
+
+        // A property whose change will trigger notification.
+        // Using a backing field to demonstrate logic on set.
+        private int _state;
+        public int State
+        {
+            get { return _state; }
+            set
+            {
+                _state = value;
+                Notify(); // Notify observers when the state changes
+            }
+        }
+
+        public void Attach(IObserver observer)
+        {
+            if (!_observers.Contains(observer))
+            {
+                _observers.Add(observer);
+                Console.WriteLine("Subject: Attached an observer.");
+            }
+        }
+
+        public void Detach(IObserver observer)
+        {
+            if (_observers.Remove(observer))
+            {
+                Console.WriteLine("Subject: Detached an observer.");
+            }
+        }
+
+        public void Notify()
+        {
+            Console.WriteLine($"Subject: Notifying observers about state change to: {State}");
+            // It's important to iterate over a copy of the list if observers
+            // might detach themselves during the Update call, to avoid modification
+            // of the collection during iteration.
+            foreach (var observer in new List<IObserver>(_observers))
+            {
+                observer.Update(this);
+            }
+        }
+
+        // Example method that might cause state change
+        public void SomeBusinessLogic()
+        {
+            Console.WriteLine("\nSubject: I'm doing something important.");
+            this.State = new System.Random().Next(0, 10); // Simulate state change
+
+            Console.WriteLine($"Subject: My state has just changed to: {this.State}");
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces a new project demonstrating the Observer design pattern in C#.

The project includes:
- IObserver and ISubject interfaces.
- A ConcreteSubject class (Subject) that maintains a list of observers and notifies them of state changes.
- Two ConcreteObserver classes (ConcreteObserverA and ConcreteObserverB) that react to subject updates.
- A Program.cs file that demonstrates the pattern's usage: attaching observers, changing subject state, and detaching observers.
- A README.md file explaining the pattern, project structure, and how to run the example.

The implementation adheres to SOLID, KISS, and DRY principles. The new project has also been added to the DesignPatterns.sln solution file.